### PR TITLE
Convert rc_sim imports to crate-relative

### DIFF
--- a/src/bin/demo.rs
+++ b/src/bin/demo.rs
@@ -1,4 +1,4 @@
-use rc_sim::projector::aib_project;
+use crate::projector::aib_project;
 use rand::Rng;               // add rand = "0.8" in Cargo.toml
 
 fn main() {

--- a/src/bin/graph_demo.rs
+++ b/src/bin/graph_demo.rs
@@ -1,4 +1,4 @@
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 fn main() {
     let mut g = Graph::complete_random(4);

--- a/src/bin/mc_demo.rs
+++ b/src/bin/mc_demo.rs
@@ -7,8 +7,8 @@
 //!   • writes CSV with the `csv` crate
 //!   • shows a live progress bar with `indicatif`
 
-use rc_sim::graph::{Graph, StepInfo};
-use rc_sim::measure::Recorder;
+use crate::graph::{Graph, StepInfo};
+use crate::measure::Recorder;
 
 use rand::{SeedableRng, RngCore};
 use rand_chacha::ChaCha20Rng;

--- a/src/bin/scan.rs
+++ b/src/bin/scan.rs
@@ -5,7 +5,7 @@
 //
 //  Compile & run:  `cargo run --bin scan`
 
-use rc_sim::graph::{Graph, StepInfo};
+use crate::graph::{Graph, StepInfo};
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! Parameter scan for the relational‑connection model
 //! (see `Config` below for all run parameters).
 
-use rc_sim::graph::{Graph, StepInfo};          // `StepInfo` is new, see comment below.
+use crate::graph::{Graph, StepInfo};          // `StepInfo` is new, see comment below.
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;

--- a/tests/dougal_invariance_test.rs
+++ b/tests/dougal_invariance_test.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 #[test]
 fn test_dougal_invariant_action() {

--- a/tests/dougal_test.rs
+++ b/tests/dougal_test.rs
@@ -1,4 +1,4 @@
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 #[test]
 fn test_entropy_scaling_law() {

--- a/tests/entropy_test.rs
+++ b/tests/entropy_test.rs
@@ -1,4 +1,4 @@
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 #[test]
 fn test_entropy_on_two_nodes() {

--- a/tests/graph_projection_test.rs
+++ b/tests/graph_projection_test.rs
@@ -1,4 +1,4 @@
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 #[test]
 fn test_graph_projection_reduces_norm() {

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -1,4 +1,4 @@
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 #[test]
 fn test_complete_graph_sizes() {

--- a/tests/metropolis_test.rs
+++ b/tests/metropolis_test.rs
@@ -1,6 +1,6 @@
 //! Unit‑test: basic sanity check on Metropolis acceptance rate.
 
-use rc_sim::graph::{Graph, StepInfo};
+use crate::graph::{Graph, StepInfo};
 
 use rand::{SeedableRng, RngCore};
 use rand_chacha::ChaCha20Rng;

--- a/tests/projector_test.rs
+++ b/tests/projector_test.rs
@@ -1,5 +1,5 @@
-//use rc_sim::projector::{count_nonzero_components};
-use rc_sim::projector::{aib_project, frobenius_norm, flatten};
+//use crate::projector::{count_nonzero_components};
+use crate::projector::{aib_project, frobenius_norm, flatten};
 use rand::Rng;
 use nalgebra::DMatrix;
 

--- a/tests/triangle_test.rs
+++ b/tests/triangle_test.rs
@@ -1,4 +1,4 @@
-use rc_sim::graph::Graph;
+use crate::graph::Graph;
 
 #[test]
 fn test_triangle_action_identity() {


### PR DESCRIPTION
## Summary
- switch rc_sim imports to use `crate::`
- update integration tests accordingly

## Testing
- `cargo test` *(fails: failed to parse manifest at `Cargo.toml` – found duplicate binary name scan)*

------
https://chatgpt.com/codex/tasks/task_e_68441c87c42c8321a62e3f13305ee6d6