### PR TITLE
Fix cargo manifest and imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,31 @@
 version = 4
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "cfg-if"
@@ -138,10 +159,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "number_prefix"
@@ -154,6 +249,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portable-atomic"
@@ -219,6 +320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,11 +352,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scan"
 version = "0.2.0"
 dependencies = [
  "csv",
  "indicatif",
+ "nalgebra",
  "rand",
  "rand_chacha",
  "rayon",
@@ -276,6 +393,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +415,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
@@ -369,6 +505,16 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,9 @@ edition = "2021"
 
 [dependencies]
 rand         = { version = "0.8", features = ["small_rng", "std"] }
-rand_chacha   = { version = "0.3" }
-rayon         = { version = "1.10" }
-csv           = { version = "1.3" }
-indicatif     = { version = "0.17" }
-
-# Your simulation crate
-rc_sim        = { path = "../relational-contrast-sim" }   # Ensure the path points to the rc_sim crate. For example, if the project structure changes, verify the path using `ls ../rc_sim` or adjust it to the new location, such as `path = "./libs/rc_sim"`.
+rand_chacha  = { version = "0.3" }
+rayon        = { version = "1.10" }
+csv          = { version = "1.3" }
+indicatif    = { version = "0.17" }
+nalgebra     = { version = "0.32" }
 

--- a/src/bin/beta_alpha_scan.rs
+++ b/src/bin/beta_alpha_scan.rs
@@ -3,9 +3,9 @@
 //! Parameters are kept in one `Config` struct so comments never
 //! drift out of sync with the executable settings.
 //
-//  Compile & run:  `cargo run --bin scan`
+//  Compile & run:  `cargo run --bin beta_alpha_scan`
 
-use crate::graph::{Graph, StepInfo};
+use scan::graph::{Graph, StepInfo};
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
@@ -16,7 +16,7 @@ use std::sync::Mutex;
 // -----------------------------------------------------------------------------
 // Configuration
 // -----------------------------------------------------------------------------
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Config {
     n_nodes:      usize,
     n_steps:      usize,

--- a/src/bin/demo.rs
+++ b/src/bin/demo.rs
@@ -1,4 +1,4 @@
-use crate::projector::aib_project;
+use scan::projector::aib_project;
 use rand::Rng;               // add rand = "0.8" in Cargo.toml
 
 fn main() {

--- a/src/bin/graph_demo.rs
+++ b/src/bin/graph_demo.rs
@@ -1,4 +1,4 @@
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 fn main() {
     let mut g = Graph::complete_random(4);
@@ -12,7 +12,7 @@ fn main() {
     let lambda = 2.0;
     let s_before = g.entropy_action();
     let sum_w: f64 = g.links.iter().map(|l| l.w).sum();
-    g.rescale_weights(lambda);
+    g.rescale(lambda);
     let s_after = g.entropy_action();
     let expected  = lambda * s_before + lambda * sum_w * lambda.ln();
     println!("  S(λw)        = {:.6}", s_after);

--- a/src/bin/mc_demo.rs
+++ b/src/bin/mc_demo.rs
@@ -7,8 +7,8 @@
 //!   • writes CSV with the `csv` crate
 //!   • shows a live progress bar with `indicatif`
 
-use crate::graph::{Graph, StepInfo};
-use crate::measure::Recorder;
+use scan::graph::{Graph, StepInfo};
+use scan::measure::Recorder;
 
 use rand::{SeedableRng, RngCore};
 use rand_chacha::ChaCha20Rng;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! Parameter scan for the relational‑connection model
 //! (see `Config` below for all run parameters).
 
-use crate::graph::{Graph, StepInfo};          // `StepInfo` is new, see comment below.
+use scan::graph::{Graph, StepInfo};          // `StepInfo` is new, see comment below.
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;

--- a/tests/dougal_invariance_test.rs
+++ b/tests/dougal_invariance_test.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 #[test]
 fn test_dougal_invariant_action() {

--- a/tests/dougal_test.rs
+++ b/tests/dougal_test.rs
@@ -1,4 +1,4 @@
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 #[test]
 fn test_entropy_scaling_law() {
@@ -8,7 +8,7 @@ fn test_entropy_scaling_law() {
 
     // Rescale
     let lambda = 2.5_f64;
-    g.rescale_weights(lambda);
+    g.rescale(lambda);
     let s1 = g.entropy_action();
 
     let expected = lambda * s0 + lambda * w0 * lambda.ln();

--- a/tests/entropy_test.rs
+++ b/tests/entropy_test.rs
@@ -1,4 +1,4 @@
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 #[test]
 fn test_entropy_on_two_nodes() {

--- a/tests/graph_projection_test.rs
+++ b/tests/graph_projection_test.rs
@@ -1,4 +1,4 @@
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 #[test]
 fn test_graph_projection_reduces_norm() {

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -1,4 +1,4 @@
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 #[test]
 fn test_complete_graph_sizes() {

--- a/tests/metropolis_test.rs
+++ b/tests/metropolis_test.rs
@@ -1,6 +1,6 @@
 //! Unit‑test: basic sanity check on Metropolis acceptance rate.
 
-use crate::graph::{Graph, StepInfo};
+use scan::graph::{Graph, StepInfo};
 
 use rand::{SeedableRng, RngCore};
 use rand_chacha::ChaCha20Rng;

--- a/tests/projector_test.rs
+++ b/tests/projector_test.rs
@@ -1,5 +1,5 @@
-//use crate::projector::{count_nonzero_components};
-use crate::projector::{aib_project, frobenius_norm, flatten};
+//use scan::projector::{count_nonzero_components};
+use scan::projector::{aib_project, frobenius_norm, flatten};
 use rand::Rng;
 use nalgebra::DMatrix;
 

--- a/tests/triangle_test.rs
+++ b/tests/triangle_test.rs
@@ -1,4 +1,4 @@
-use crate::graph::Graph;
+use scan::graph::Graph;
 
 #[test]
 fn test_triangle_action_identity() {


### PR DESCRIPTION
## Summary
- rename duplicate binary to `beta_alpha_scan`
- remove self-dependency and add `nalgebra`
- update bin and test imports to use crate name `scan`
- update project to compile and tests to pass

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68441e96d2b883218b34d77e07dd756a